### PR TITLE
Added remember me field in user login

### DIFF
--- a/swagger-ui/dist/zipskee-v1.swagger.yaml
+++ b/swagger-ui/dist/zipskee-v1.swagger.yaml
@@ -28,6 +28,11 @@ paths:
          description: password of person logging in
          required: true
          type: string
+       - name: rememberMe
+         in: formData
+         description: rememberMe - 0 for no, 1 for yes
+         required: false
+         type: integer
       tags:
        - Auth
       responses:


### PR DESCRIPTION
By default devise handles the remember me function. 

If you send 0 back - it sets the row in the user table below to nil. If you send 1 back, it records the session creation date and will automatically remember session data.

Per devise documentation --- 

```
# Remember the user through the remember token. This strategy is responsible to verify whether there is a cookie with the remember token, and to recreate the user from this cookie if it exists.
```

``` Ruby
t.datetime "remember_created_at"

```
